### PR TITLE
Restore DB credentials to match the one in docker-compose.yml

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,8 +1,8 @@
 spring:
   datasource:
     url: jdbc:postgresql://localhost:5432/yoga-class-app
-    username: user
-    password: password
+    username: mustafa
+    password: 123456789
   main:
     banner-mode: off
   jpa:


### PR DESCRIPTION
When I changed credentials by mistake in `application.yml` file, we didn't care about restoring it back but:
- We should restore them back like in this PR.
- or change `docker-compose.yml` credentials to match the one in `application.yml`.

because this caused issue when I tried to  clean install the project and application couldn't start because it couldn't connect to DB.