### PR TITLE
Remove extra unnecessary slash in GetMapping & PostMapping

### DIFF
--- a/src/main/java/com/horus/yoga/controller/UserController.java
+++ b/src/main/java/com/horus/yoga/controller/UserController.java
@@ -26,14 +26,14 @@ public class UserController implements BaseController<User, UserDTO> {
         return APIResponse.ok(user);
     }
 
-    @GetMapping("/")
+    @GetMapping
     public APIResponse<List<UserDTO>> getAll() {
         List<UserDTO> users = userService.getAll();
         return APIResponse.ok(users);
     }
 
 
-    @PostMapping("/")
+    @PostMapping
     public APIResponse<UserDTO> create(@RequestBody User user) {
         UserDTO newUser = userService.create(user);
         return APIResponse.ok(newUser);

--- a/src/main/java/com/horus/yoga/controller/UserController.java
+++ b/src/main/java/com/horus/yoga/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController implements BaseController<User, UserDTO> {
     }
 
 
-    @PostMapping
+    @PostMapping("/")
     public APIResponse<UserDTO> create(@RequestBody User user) {
         UserDTO newUser = userService.create(user);
         return APIResponse.ok(newUser);


### PR DESCRIPTION
This Extra slash is causing a lot of trouble and it doesn't make any sense to add it.

Removed from:
- @GetMapping  (only with getAll() method)
- @PostMapping